### PR TITLE
Improve board rendering and client UI

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -28,7 +28,7 @@ class Client():
 			self.viewer = True
 			self.color = 0
 
-		self.chess_app = App((500,500), self.color, self.handle_highlight, self.handle_move, self.quit_game, self.reset_board);
+		self.chess_app = App((600,600), self.color, self.handle_highlight, self.handle_move, self.quit_game, self.reset_board);
 
 	def quit_game(self):
 		self.ready_quit = True
@@ -57,10 +57,12 @@ class Client():
 		if content == "-1":
 			return []
 
-		tile_indices = []
-		for tile in content.split(","):
-			index = (ord(tile[0]) - ord("a")) + (ord(tile[1]) - ord("1")) * 8
-			tile_indices.append(index)
+			tile_indices = []
+			for tile in content.split(","):
+				file = ord(tile[0]) - ord("a")
+				rank = ord(tile[1]) - ord("1")
+				index = (7 - rank) * 8 + file
+				tile_indices.append(index)
 
 		return tile_indices
 
@@ -68,19 +70,6 @@ class Client():
 		status, content = self.take_action(MOVE, [rf_from, rf_to])
 		return content
 
-	def mainloop(self):
-		last_update = time.time()
-		delta = 0.5
-		while not self.ready_quit:
-			self.chess_app.refresh()
-
-			curr_time = time.time()
-			if curr_time - last_update > delta:
-				last_update = delta
-				status, content = self.take_action(VIEW, None)
-				self.chess_app.board.render_fen(FEN_String(content))
-
-		self.server.close()
 
 
 	def reset_board(self):


### PR DESCRIPTION
## Summary
- fix board image resizing to fit tile size
- adjust window and board geometry based on a computed tile size
- show player's color in the window
- correct tile coordinate conversion for server responses
- remove duplicate code in client

## Testing
- `python -m py_compile Client/Board.py Client/Client.py Client/FEN.py app.py sprites/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6862e97d915883228a9197f5bc119ad7