### PR TITLE
Add dynamic board resizing

### DIFF
--- a/Client/Board.py
+++ b/Client/Board.py
@@ -113,6 +113,25 @@ class Board(Canvas):
 
         self.moves = [set(), set(), set(), set()]
 
+    def resize(self, tile_size):
+        """Resize the board and all sprites to a new tile size."""
+        self.tile_size = tile_size
+        board_size = tile_size * 8
+        self.config(width=board_size, height=board_size)
+
+        for idx, tile in enumerate(self.tiles):
+            j, i = divmod(idx, 8)
+            x1 = i * tile_size
+            x2 = (i + 1) * tile_size
+            y1 = board_size - j * tile_size
+            y2 = board_size - (j + 1) * tile_size
+            self.coords(tile.box, x1, y1, x2, y2)
+            self.coords(tile.img_obj, x1 + tile_size/2, y2 + tile_size/2)
+            tile.size = tile_size
+            tile.set_piece(tile.state, optimize=False)
+
+        self.draw_labels()
+
     def create_mappings(self):
         self.board_to_fen = []
         self.fen_to_board = []
@@ -234,17 +253,19 @@ class Board(Canvas):
 
         label_font = ('Arial', int(self.tile_size * 0.3))
 
+        self.delete('label')
+
         # file labels along the bottom
         for i, f in enumerate(files):
             x = (i + 0.5) * self.tile_size
             y = board_size - self.tile_size * 0.1
-            self.create_text(x, y, text=f, font=label_font)
+            self.create_text(x, y, text=f, font=label_font, tags='label')
 
         # rank labels along the left side
         for i, r in enumerate(ranks):
             x = self.tile_size * 0.1
             y = board_size - (i + 0.5) * self.tile_size
-            self.create_text(x, y, text=r, font=label_font)
+            self.create_text(x, y, text=r, font=label_font, tags='label')
 
     def render_fen(self, fen_string):
         if fen_string.string == self.last_fen:
@@ -278,14 +299,14 @@ class App(Tk):
         self.size = (board_size, board_size)
         self.color = color
 
-        self.resizable(0, 0)
+        self.resizable(True, True)
         self.geometry(f"{board_size}x{board_size + 120}+{(screen_width // 2) - (board_size // 2)}+{(screen_height // 2) - ((board_size + 120) // 2)}")
         self.title("Chess Engine")
         self.attributes('-topmost', True)
 
         # Darker wooden border around the board
         self.frame = Frame(self, bg='#8b4513', bd=70)
-        self.frame.pack()
+        self.frame.pack(expand=True, fill=BOTH)
 
         self.board = Board(
             self.color,
@@ -297,7 +318,7 @@ class App(Tk):
             bd=0,
             bg='#f0d9b5'
         )
-        self.board.pack()
+        self.board.pack(expand=True, fill=BOTH)
 
         color_text = "White" if self.color == WHITE else "Black"
         self.color_label = Label(self, text=f"You are {color_text}", font=('Arial', 12))
@@ -312,6 +333,7 @@ class App(Tk):
         self.reset_handler = reset_handler
 
         self.bind('q', self.leave)
+        self.board.bind('<Configure>', self.on_board_resize)
 
     def leave(self, e):
         print("QUITTING")
@@ -321,6 +343,12 @@ class App(Tk):
     def refresh(self):
         self.update_idletasks()
         self.update()
+
+    def on_board_resize(self, event):
+        new_tile = min(event.width, event.height) / 8
+        if abs(new_tile - self.board.tile_size) < 1:
+            return
+        self.board.resize(new_tile)
 
     def reset(self):
         print('reseting')


### PR DESCRIPTION
## Summary
- make the Tk window resizable
- dynamically resize board tiles, sprites and labels when the window changes

## Testing
- `python -m py_compile Client/*.py`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6862f33d4cb08322817daa7e6cfd730f