### PR TITLE
Enable zobrist based transposition table

### DIFF
--- a/Server/board.c
+++ b/Server/board.c
@@ -46,8 +46,10 @@ void load_magic_file(const char *filename, MagicData *table) {
     }
 
     for (int i = 0; i < 64; i++) {
-        fread(&table[i].magic_bitboard, sizeof(Bitboard), 1, fp);
-        fread(&table[i].bits_used, sizeof(int), 1, fp);
+        size_t r1 = fread(&table[i].magic_bitboard, sizeof(Bitboard), 1, fp);
+        (void)r1;
+        size_t r2 = fread(&table[i].bits_used, sizeof(int), 1, fp);
+        (void)r2;
 
         int count = 1 << table[i].bits_used;
         table[i].array_of_moves = malloc(sizeof(Bitboard) * count);
@@ -56,7 +58,8 @@ void load_magic_file(const char *filename, MagicData *table) {
             exit(1);
         }
 
-        fread(table[i].array_of_moves, sizeof(Bitboard), count, fp);
+        size_t r3 = fread(table[i].array_of_moves, sizeof(Bitboard), count, fp);
+        (void)r3;
     }
 
     fclose(fp);

--- a/Server/chess_agent.c
+++ b/Server/chess_agent.c
@@ -213,16 +213,40 @@ void process_task(Board state, int fd, Bitboard inital_tile) {
 }
 
 void alphabeta(Board *state, int depth, int alpha, int beta, int maximize_player, struct alphabeta_response * best_info, Bitboard only_check_mask) {
-	// struct board_data *data = hash_find(zobrist.hashtable, state->z_hash);
-	int best_score;
+        Hash board_hash = state->z_hash;
+        int best_score;
+        int alpha_orig = alpha;
+        int beta_orig = beta;
+
+        struct board_data *entry = hash_find(zobrist.hashtable, board_hash);
+        if (entry && entry->depth >= depth) {
+                if (entry->flags == EXACT) {
+                        best_info->score = entry->eval_score;
+                        best_info->move = entry->best_move;
+                        return;
+                } else if (entry->flags == LOWER) {
+                        alpha = max(alpha, entry->eval_score);
+                } else if (entry->flags == UPPER) {
+                        beta = min(beta, entry->eval_score);
+                }
+
+                if (alpha >= beta) {
+                        best_info->score = entry->eval_score;
+                        best_info->move = entry->best_move;
+                        return;
+                }
+        }
 
 	// printf("Depth: %d\n",depth);
-	if (depth == 0 || check_flag(state, TERMINAL)) {
-		int eval_score = evaluate_board(state);
-		best_info->score = eval_score;
-		best_info->move = NULL_MOVE;
-		return;
-	}
+        if (depth == 0 || check_flag(state, TERMINAL)) {
+                int eval_score = evaluate_board(state);
+                best_info->score = eval_score;
+                best_info->move = 0;
+
+                struct board_data data = { .eval_score = eval_score, .depth = depth, .flags = EXACT, .best_move = 0 };
+                hash_insert(zobrist.hashtable, board_hash, data);
+                return;
+        }
 
 	
 	Move move_list[MAX_MOVES];
@@ -234,58 +258,70 @@ void alphabeta(Board *state, int depth, int alpha, int beta, int maximize_player
 
 	if (move_count == 0) {
 		// printf("NO MOVES (CHECKMATE)\n");
-		best_info->score = (maximize_player) ? -1000000 : 1000000;
-		best_info->move = NULL_MOVE;
+                best_info->score = (maximize_player) ? -1000000 : 1000000;
+                best_info->move = 0;
 		return;
 	}
 
-	if (maximize_player == TRUE) {
-		best_score = INT_MIN;
+        Move best_move_local = 0;
 
-		for (int i = 0; i < move_count; i++) {
-			Board board = *state;
-			move_status_error = move_piece(&board, move_list[i]);
-			if (move_status_error) { // illegal move
-				continue;
-			}
-			checked_boards += 1;
+        if (maximize_player == TRUE) {
+                best_score = INT_MIN;
 
-			// find max score
-			alphabeta(&board, depth - 1, alpha, beta, FALSE, &response, CHECK_ALL);
+                for (int i = 0; i < move_count; i++) {
+                        Board board = *state;
+                        move_status_error = move_piece(&board, move_list[i]);
+                        if (move_status_error) {
+                                continue;
+                        }
+                        checked_boards += 1;
 
-			if (response.score > best_score) {
-				best_info->move = move_list[i];
-				best_info->score = response.score;
-				best_score = response.score; // this could be removed
+                        alphabeta(&board, depth - 1, alpha, beta, FALSE, &response, CHECK_ALL);
 
-				alpha = max(alpha, best_score);
-				if (alpha >= beta) break;
-			}
-						
-		}
+                        if (response.score > best_score) {
+                                best_move_local = move_list[i];
+                                best_score = response.score;
+                        }
 
-	} else {
-		best_score = INT_MAX;
+                        alpha = max(alpha, best_score);
+                        if (alpha >= beta) break;
+                }
 
-		for (int i = 0; i < move_count; i++) {
-			Board board = *state;
-			move_status_error = move_piece(&board, move_list[i]);
-			if (move_status_error) { // illegal move
-				continue;
-			}
+        } else {
+                best_score = INT_MAX;
 
-			
-			// find min score
-			alphabeta(&board, depth - 1, alpha, beta, TRUE, &response, CHECK_ALL);
+                for (int i = 0; i < move_count; i++) {
+                        Board board = *state;
+                        move_status_error = move_piece(&board, move_list[i]);
+                        if (move_status_error) {
+                                continue;
+                        }
 
-			if (response.score < best_score) {
-				best_info->move = move_list[i];
-				best_info->score = response.score;
-				best_score = response.score; // this could be removed
 
-				beta = min(beta, best_score);
-				if (alpha >= beta) break;
-			}
-		}
-	}
+                        alphabeta(&board, depth - 1, alpha, beta, TRUE, &response, CHECK_ALL);
+
+                        if (response.score < best_score) {
+                                best_move_local = move_list[i];
+                                best_score = response.score;
+                        }
+
+                        beta = min(beta, best_score);
+                        if (alpha >= beta) break;
+                }
+        }
+
+        best_info->move = best_move_local;
+        best_info->score = best_score;
+
+        HashFlag flag;
+        if (best_score <= alpha_orig) {
+                flag = UPPER;
+        } else if (best_score >= beta_orig) {
+                flag = LOWER;
+        } else {
+                flag = EXACT;
+        }
+
+        struct board_data new_entry = { .eval_score = best_score, .depth = depth, .flags = flag, .best_move = best_move_local };
+        hash_insert(zobrist.hashtable, board_hash, new_entry);
 }

--- a/Server/server.c
+++ b/Server/server.c
@@ -82,7 +82,8 @@ void handle_request(int fd, char *socket_buff, int length, struct thread_args ar
     } else if (cmd == RESTART) {
         reset_board(&board);
         printf("reset board\n");
-        write(fd, "RESET", 5);
+        ssize_t w = write(fd, "RESET", 5);
+        (void)w;
         return;
     }
     ssize_t w = write(fd, "ERROR", 5);


### PR DESCRIPTION
## Summary
- cache search results in a hashtable using zobrist hashes
- mark board hashing reads/writes in load_magic_file and server restart
- return cached results during alphabeta search

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6863703d35c0832294f40a9b4f0a4b27