### PR TITLE
Optimize AI with thread pool and fix move sorting

### DIFF
--- a/Server/Makefile
+++ b/Server/Makefile
@@ -1,11 +1,11 @@
 CC = cc
 
 # Compiler and linker flags
-CFLAGS = -Wall -Werror -I./includes -O3 -march=native -flto -fomit-frame-pointer -DNDEBUG
-LDFLAGS = -flto -O3 -march=native
+CFLAGS = -Wall -Werror -I./includes -O3 -march=native -flto -fomit-frame-pointer -DNDEBUG -pthread
+LDFLAGS = -flto -O3 -march=native -pthread
 
 # Source files
-SRCS = server.c board.c hash.c zobrist_hash.c chess_agent.c piece_evaluator.c
+SRCS = server.c board.c hash.c zobrist_hash.c chess_agent.c piece_evaluator.c thread_pool.c
 
 # Object files
 OBJS = $(SRCS:.c=.o)

--- a/Server/includes/prototypes.h
+++ b/Server/includes/prototypes.h
@@ -68,7 +68,6 @@ Hash update_pawn_promote(int, Piece, Color);
 
 Move select_move(Board *);
 void alphabeta(Board *, int, int, int, int, struct alphabeta_response *, Bitboard);
-void process_task(Board, int, Bitboard);
 
 
 // PIECE EVALUATOR

--- a/Server/includes/thread_pool.h
+++ b/Server/includes/thread_pool.h
@@ -1,0 +1,33 @@
+#ifndef THREAD_POOL_H
+#define THREAD_POOL_H
+
+#include <pthread.h>
+#include "structs.h"
+
+typedef void (*task_func)(void *);
+
+typedef struct pool_task {
+    task_func func;
+    void *arg;
+    struct pool_task *next;
+    pthread_mutex_t lock;
+    pthread_cond_t cond;
+    int done;
+} PoolTask;
+
+typedef struct thread_pool {
+    pthread_t *threads;
+    int num_threads;
+    PoolTask *head;
+    PoolTask *tail;
+    int stop;
+    pthread_mutex_t queue_lock;
+    pthread_cond_t queue_cond;
+} ThreadPool;
+
+void pool_init(ThreadPool *pool, int num_threads);
+void pool_add_task(ThreadPool *pool, PoolTask *task);
+void pool_wait_task(PoolTask *task);
+void pool_destroy(ThreadPool *pool);
+
+#endif // THREAD_POOL_H

--- a/Server/thread_pool.c
+++ b/Server/thread_pool.c
@@ -1,0 +1,83 @@
+#include "includes/chess.h"
+#include "includes/thread_pool.h"
+#include <stdlib.h>
+
+static void *worker(void *arg) {
+    ThreadPool *pool = (ThreadPool *)arg;
+    while (1) {
+        pthread_mutex_lock(&pool->queue_lock);
+        while (!pool->head && !pool->stop) {
+            pthread_cond_wait(&pool->queue_cond, &pool->queue_lock);
+        }
+        if (pool->stop && !pool->head) {
+            pthread_mutex_unlock(&pool->queue_lock);
+            break;
+        }
+        PoolTask *task = pool->head;
+        pool->head = task->next;
+        if (!pool->head)
+            pool->tail = NULL;
+        pthread_mutex_unlock(&pool->queue_lock);
+
+        task->func(task->arg);
+
+        pthread_mutex_lock(&task->lock);
+        task->done = 1;
+        pthread_cond_signal(&task->cond);
+        pthread_mutex_unlock(&task->lock);
+    }
+    return NULL;
+}
+
+void pool_init(ThreadPool *pool, int num_threads) {
+    pool->threads = malloc(sizeof(pthread_t) * num_threads);
+    pool->num_threads = num_threads;
+    pool->head = pool->tail = NULL;
+    pool->stop = 0;
+    pthread_mutex_init(&pool->queue_lock, NULL);
+    pthread_cond_init(&pool->queue_cond, NULL);
+    for (int i = 0; i < num_threads; i++) {
+        pthread_create(&pool->threads[i], NULL, worker, pool);
+    }
+}
+
+void pool_add_task(ThreadPool *pool, PoolTask *task) {
+    task->next = NULL;
+    task->done = 0;
+    pthread_mutex_init(&task->lock, NULL);
+    pthread_cond_init(&task->cond, NULL);
+
+    pthread_mutex_lock(&pool->queue_lock);
+    if (pool->tail)
+        pool->tail->next = task;
+    else
+        pool->head = task;
+    pool->tail = task;
+    pthread_cond_signal(&pool->queue_cond);
+    pthread_mutex_unlock(&pool->queue_lock);
+}
+
+void pool_wait_task(PoolTask *task) {
+    pthread_mutex_lock(&task->lock);
+    while (!task->done) {
+        pthread_cond_wait(&task->cond, &task->lock);
+    }
+    pthread_mutex_unlock(&task->lock);
+    pthread_mutex_destroy(&task->lock);
+    pthread_cond_destroy(&task->cond);
+}
+
+void pool_destroy(ThreadPool *pool) {
+    pthread_mutex_lock(&pool->queue_lock);
+    pool->stop = 1;
+    pthread_cond_broadcast(&pool->queue_cond);
+    pthread_mutex_unlock(&pool->queue_lock);
+
+    for (int i = 0; i < pool->num_threads; i++) {
+        pthread_join(pool->threads[i], NULL);
+    }
+
+    pthread_mutex_destroy(&pool->queue_lock);
+    pthread_cond_destroy(&pool->queue_cond);
+    free(pool->threads);
+}


### PR DESCRIPTION
## Summary
- add a simple pthread-based thread pool implementation
- use the thread pool in `select_move` instead of forking processes
- fix in-place `qsort` call when generating moves
- link with pthread and compile the new thread_pool source

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6863722cbec483229fe9fd1a9790e240