### PR TITLE
Optimize attack square generation

### DIFF
--- a/Server/chess_agent.c
+++ b/Server/chess_agent.c
@@ -126,9 +126,9 @@ int evaluate_board(Board *state) {
 
 	score += evaluate_pieces(state);
 
-	// make use of number of attack locations
-	Bitboard attack_moves_white = generate_attackable_squares(state, WHITE);
-	Bitboard attack_moves_black = generate_attackable_squares(state, BLACK);
+        // make use of number of attack locations
+        Bitboard attack_moves_white = state->attackable[WHITE];
+        Bitboard attack_moves_black = state->attackable[BLACK];
 
 	attack_score = __builtin_popcountll(attack_moves_white) - __builtin_popcountll(attack_moves_black);
 


### PR DESCRIPTION
## Summary
- avoid recalculating attackable squares in `evaluate_board`
- initialize attackable bitboards when creating a board
- rewrite `generate_attackable_squares` to iterate using bitboards for each piece type

## Testing
- `make -C Server clean`
- `make -C Server`

------
https://chatgpt.com/codex/tasks/task_e_686376e0e400832298430b2757903106