### PR TITLE
Add zobrist hash and transposition table

### DIFF
--- a/Server/chess_agent.c
+++ b/Server/chess_agent.c
@@ -213,10 +213,10 @@ void generate_all_moves(Board *state, Move *move_list, int *move_count, Bitboard
 void alphabeta(Board *state, int depth, int alpha, int beta, int maximize_player, struct alphabeta_response * best_info, Bitboard only_check_mask) {
         Hash board_hash = state->z_hash;
         int best_score;
-        // int alpha_orig = alpha;
-        // int beta_orig = beta;
+        int alpha_orig = alpha;
+        int beta_orig = beta;
 
-        struct board_data *entry = hash_find(zobrist.hashtable, board_hash);
+        struct board_data *entry = tt_lookup(board_hash);
         if (entry && entry->depth >= depth) {
                 if (entry->flags == EXACT) {
                         best_info->score = entry->eval_score;
@@ -241,8 +241,7 @@ void alphabeta(Board *state, int depth, int alpha, int beta, int maximize_player
                 best_info->score = eval_score;
                 best_info->move = 0;
 
-                // struct board_data data = { .eval_score = eval_score, .depth = depth, .flags = EXACT, .best_move = 0 };
-                // hash_insert(zobrist.hashtable, board_hash, data);
+                tt_store(board_hash, eval_score, depth, EXACT, 0);
                 return;
         }
 
@@ -311,15 +310,14 @@ void alphabeta(Board *state, int depth, int alpha, int beta, int maximize_player
         best_info->move = best_move_local;
         best_info->score = best_score;
 
-        // HashFlag flag;
-        // if (best_score <= alpha_orig) {
-        //         flag = UPPER;
-        // } else if (best_score >= beta_orig) {
-        //         flag = LOWER;
-        // } else {
-        //         flag = EXACT;
-        // }
+        HashFlag flag;
+        if (best_score <= alpha_orig) {
+                flag = UPPER;
+        } else if (best_score >= beta_orig) {
+                flag = LOWER;
+        } else {
+                flag = EXACT;
+        }
 
-        // struct board_data new_entry = { .eval_score = best_score, .depth = depth, .flags = flag, .best_move = best_move_local };
-        // hash_insert(zobrist.hashtable, board_hash, new_entry);
+        tt_store(board_hash, best_score, depth, flag, best_move_local);
 }

--- a/Server/includes/prototypes.h
+++ b/Server/includes/prototypes.h
@@ -66,6 +66,10 @@ Hash get_board_hash(Board *);
 Hash update_zobrist_capture(int, Piece, Color);
 Hash update_zobrist_turn();
 Hash update_pawn_promote(int, Piece, Color);
+
+struct board_data *tt_lookup(Hash);
+void tt_store(Hash, int, int, HashFlag, Move);
+void tt_clear();
 // AI PROTOTYPES
 
 Move select_move(Board *);

--- a/Server/includes/zobrist_hash.h
+++ b/Server/includes/zobrist_hash.h
@@ -1,4 +1,10 @@
 #ifndef _Z_HASH_H_
 #define _Z_HASH_H_
 
+#include "structs.h"
+
+struct board_data *tt_lookup(Hash hash);
+void tt_store(Hash hash, int eval_score, int depth, HashFlag flag, Move best_move);
+void tt_clear();
+
 #endif

--- a/Server/zobrist_hash.c
+++ b/Server/zobrist_hash.c
@@ -88,6 +88,23 @@ Hash update_pawn_promote(int square, Piece to_piece, Color color) {
     return hash;
 }
 
+struct board_data *tt_lookup(Hash hash) {
+    return (struct board_data *)hash_find(zobrist.hashtable, hash);
+}
+
+void tt_store(Hash hash, int eval_score, int depth, HashFlag flag, Move best_move) {
+    struct board_data *entry = malloc(sizeof(struct board_data));
+    entry->eval_score = eval_score;
+    entry->depth = depth;
+    entry->flags = flag;
+    entry->best_move = best_move;
+    hash_insert(zobrist.hashtable, hash, entry);
+}
+
+void tt_clear() {
+    hash_clear(zobrist.hashtable);
+}
+
 // HashEntry *check_zobrist(Zobrist *zobrist, Hash hash) {
 // 	return hash_find(zobrist->hashtable, hash);
 // }


### PR DESCRIPTION
## Summary
- implement transposition table using the zobrist hashtable
- use `tt_lookup` and `tt_store` in `alphabeta`
- expose new prototypes for the transposition helpers

## Testing
- `make` *(fails: format warnings treated as errors)*

------
https://chatgpt.com/codex/tasks/task_e_686455f97ee08322b74fc02e37179ea1